### PR TITLE
Update buffer.c

### DIFF
--- a/dependencies/MinHook/buffer.c
+++ b/dependencies/MinHook/buffer.c
@@ -311,7 +311,13 @@ VOID FreeBuffer(LPVOID pBuffer)
 BOOL IsExecutableAddress(LPVOID pAddress)
 {
     MEMORY_BASIC_INFORMATION mi;
-    VirtualQuery(pAddress, &mi, sizeof(mi));
+    if (VirtualQuery(pAddress, &mi, sizeof(mi)) != sizeof(mi))
+    {
+        // VirtualQuery failed, return FALSE
+        return FALSE;
+    }
 
-    return (mi.State == MEM_COMMIT && (mi.Protect & PAGE_EXECUTE_FLAGS));
+    // Check if the memory region is committed and executable
+    return (mi.State == MEM_COMMIT && (mi.Protect & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY)));
 }
+


### PR DESCRIPTION
Here are the changes made:

- The return value of `VirtualQuery `is checked to ensure that it is equal to the size of the `MEMORY_BASIC_INFORMATION` structure. This is necessary because VirtualQuery may fail and return a value other than the size of the structure, in which case the function should return `FALSE`.
- The `PAGE_EXECUTE_FLAGS` macro has been replaced with a combination of the four execute protection flags: `PAGE_EXECUTE`, `PAGE_EXECUTE_READ`, `PAGE_EXECUTE_READWRITE`, and PAGE_EXECUTE_WRITECOPY. These flags represent all the possible execute protection settings for a memory region, so checking for any of them ensures that the function can correctly determine whether a region is executable regardless of the specific protection setting.
- The `mi.State` field is checked to ensure that the memory region is committed before checking the protection flags. This is important because a memory region can be reserved but not committed, and a reserved region is not necessarily executable even if it has execute protection flags set.